### PR TITLE
package.json: move exports.default to last

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "hirestime",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.12",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "thin wrapper around process.hrtime",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.esm.js",
-    "types": "./dist/index.d.ts"
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.esm.js"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
In `package.json`, [conditional exports](https://nodejs.org/dist/v18.10.0/docs/api/packages.html#conditional-exports) must be listed in order from most specific to least specific.
`"default"` is a condition that always matches, and Node.js docs suggest that it SHOULD always come last.
The webpack bundler appears to enforce that `"default"` MUST come last.

hirestime v7.0.1 defines conditional exports as follows:

```json
{
  "exports": {
    "require": "./dist/index.cjs",
    "default": "./dist/index.esm.js",
    "types": "./dist/index.d.ts"
  }
}
```

This definition is incompatible with webpack bundler.
<details>
<summary>webpack error</summary>

**package.json**

```json
{
  "private": true,
  "scripts": {
    "webpack": "webpack"
  },
  "dependencies": {
    "hirestime": "^7.0.1"
  },
  "devDependencies": {
    "webpack": "^5.74.0",
    "webpack-cli": "^4.10.0"
  }
}
```

**main.js**

```js
import hirestime from "hirestime";

const t = hirestime();
console.log(t());
```

**webpack.config.js**

```js
/** @type {import("webpack").Configuration} */
module.exports = {
  mode: "development",
  entry: "./main.js",
  output: {
    filename: "bundle.js",
  },
  node: false,
};
```

**Error message**

```shell
$ npm run -s webpack
asset bundle.js 2.29 KiB [compared for emit] (name: main)
runtime modules 274 bytes 1 module
./main.js 77 bytes [built] [code generated]

ERROR in ./main.js 1:0-34
Module not found: Error: Default condition should be last one

webpack 5.74.0 compiled with 1 error in 95 ms
```

</details>

This PR rearranges the conditional exports section of `package.json` so that it comes last, making it compliant with Node.js recommendation and compatible with webpack.